### PR TITLE
Allow specifying different version configs

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -1,5 +1,5 @@
 # MIT licensed
-name: openMINDS_build_pipline
+name: openMINDS_dev_build_pipeline
 
 on:
   push:
@@ -21,10 +21,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    
+
     - name: Checkout Repository
       uses: actions/checkout@v3
-      
+
     - name: Set up Python 3.11
       uses: actions/setup-python@v2
       with:
@@ -33,19 +33,19 @@ jobs:
     - name: Run build
       run: |
         pip install -r requirements.txt
-        python build.py --repository "${{ inputs.repository }}" --branch "${{ inputs.branch }}" --config versions.json
+        python build.py --repository "${{ inputs.repository }}" --branch "${{ inputs.branch }}" --config versions-dev.json
 
-    - name: Checkout main branch
+    - name: Checkout development branch
       uses: actions/checkout@v3
       with:
-        ref: main
-        path: main
+        ref: development
+        path: development
         token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Push to main
+    - name: Push to development
       run: |
-        cp -R target/* main
-        cd main       
+        cp -R target/* development
+        cd development
         git config --global user.email "openminds@ebrains.eu"
         git config --global user.name "openMINDS pipeline"
         if [[ $(git add . --dry-run | wc -l) -gt 0 ]]; then
@@ -55,4 +55,3 @@ jobs:
         else
             echo "Nothing to commit"
         fi
-        

--- a/build.py
+++ b/build.py
@@ -10,6 +10,7 @@ from openMINDS_pipeline.vocab import TypeExtractor, Types, PropertyExtractor, Pr
 parser = argparse.ArgumentParser(prog=sys.argv[0], description='Expand openMINDS schema, extract vocabularies and instances')
 parser.add_argument('--branch', help="The branch that triggered the re-build", default=None)
 parser.add_argument('--repository', help="The repository that triggered the re-build", default=None)
+parser.add_argument('--config', help="Version configuration file", default="versions.json")
 args = vars(parser.parse_args())
 trigger = Trigger(args["branch"] if args["branch"] != "" else None, args["repository"] if args["repository"] != "" else None) if args["branch"] and args["repository"] else None
 
@@ -21,7 +22,7 @@ directory_structure = DirectoryStructure()
 clone_central(True)
 
 # Step 1 - find the versions to be (re-)built
-relevant_versions = evaluate_versions_to_be_built(trigger)
+relevant_versions = evaluate_versions_to_be_built(args.config, trigger)
 
 for version, modules in relevant_versions.items():
 
@@ -60,5 +61,3 @@ if not trigger:
     # We've built everything - this is the only chance to do a proper cleanup at the end because we know all versions have been processed.
     Types(directory_structure).clean_types()
     Property(directory_structure).clean_properties()
-
-

--- a/openMINDS_pipeline/utils.py
+++ b/openMINDS_pipeline/utils.py
@@ -47,7 +47,7 @@ def get_basic_type(property_definition:dict) -> Optional[str]:
     return basic_type
 
 
-def evaluate_versions_to_be_built(trigger:Optional[Trigger]) -> Dict[str, Dict[str, OpenMINDSModule]]:
+def evaluate_versions_to_be_built(version_config: str, trigger:Optional[Trigger]) -> Dict[str, Dict[str, OpenMINDSModule]]:
     """
     :return: the dictionary describing all versions supposed to be built either because of a change or because of a build of everything.
     """
@@ -60,7 +60,7 @@ def evaluate_versions_to_be_built(trigger:Optional[Trigger]) -> Dict[str, Dict[s
     repo = Repo.clone_from("https://github.com/openMetadataInitiative/openMINDS.git", "pipeline")
     repo.git.checkout("pipeline")
 
-    with open("pipeline/versions.json", "r") as version_specs:
+    with open(os.path.join("pipeline", version_config), "r") as version_specs:
         versions = json.load(version_specs)
     if os.path.exists("pipeline"):
         shutil.rmtree("pipeline")

--- a/versions-dev.json
+++ b/versions-dev.json
@@ -28,87 +28,73 @@
         "repository": "https://github.com/openMetadataInitiative/openMINDS_stimulation.git"
       },
       "neuroimaging": {
+        "branch": "dev",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_neuroimaging"
       }
     },
     "v1.0": {
       "SANDS": {
         "branch": "v1",
-        "commit": "e174e567600aa13fa81bc9c8f6bc1d7f9e7624c5",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_SANDS.git"
       },
       "controlledTerms": {
         "branch": "v1",
-        "commit": "2400e43e873fbfadd9f776fa69bc541a86144c8a",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_controlledTerms.git"
       },
       "core": {
         "branch": "v3",
-        "commit": "d328b5709bda8a61a3f1cb151780dfb5ef870b1a",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_core.git"
       }
     },
     "v2.0": {
       "SANDS": {
         "branch": "v2",
-        "commit": "be95b2bee743f1443167dc59ec3ffcc00a51b7db",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_SANDS.git"
       },
       "controlledTerms": {
         "branch": "v1",
-        "commit": "1fb6b233720c6ff36829a17c8025424a7db7f8f0",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_controlledTerms.git"
       },
       "core": {
         "branch": "v3",
-        "commit": "8c61d390419d35ff53ef85a13a8c4a9587af682f",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_core.git"
       }
     },
     "v3.0": {
       "SANDS": {
         "branch": "v3",
-        "commit": "ac2e238661c96bdfa98127b90dad35af6c132d50",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_SANDS.git"
       },
       "chemicals": {
         "branch": "v1",
-        "commit": "57b5ce3c6d569f0bb8ce761adb48746fd1d970b2",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_chemicals.git"
       },
       "computation": {
         "branch": "v1",
-        "commit": "57e160465c285be1780f74cffa80d16209e2a706",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_computation.git"
       },
       "controlledTerms": {
         "branch": "v1",
-        "commit": "d8bc03dce7c5764f80e2ced630dde4e572ffbb7b",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_controlledTerms.git"
       },
       "core": {
         "branch": "v4",
-        "commit": "8b2bc673cbd57a8620a306a7a84253bd6ecd30eb",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_core.git"
       },
       "ephys": {
         "branch": "v1",
-        "commit": "2accac60e9dc50116c5eee8893cffcd5b1bf24c8",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_ephys.git"
       },
       "publications": {
         "branch": "v1",
-        "commit": "d5446304a052a238d431a06bd66d0e444372f159",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_publications.git"
       },
       "specimenPrep": {
         "branch": "v1",
-        "commit": "0669813dae142946a19f00645b0d8c2d66d01975",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_specimenPrep.git"
       },
       "stimulation": {
         "branch": "v1",
-        "commit": "4dfdbadde9223ea9b6b48f377a424d23b1c8cf04",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_stimulation.git"
       }
     }

--- a/versions-dev.json
+++ b/versions-dev.json
@@ -1,0 +1,115 @@
+{
+    "latest": {
+      "SANDS": {
+        "repository": "https://github.com/openMetadataInitiative/openMINDS_SANDS.git"
+      },
+      "chemicals": {
+        "repository": "https://github.com/openMetadataInitiative/openMINDS_chemicals.git"
+      },
+      "computation": {
+        "repository": "https://github.com/openMetadataInitiative/openMINDS_computation.git"
+      },
+      "controlledTerms": {
+        "repository": "https://github.com/openMetadataInitiative/openMINDS_controlledTerms.git"
+      },
+      "core": {
+        "repository": "https://github.com/openMetadataInitiative/openMINDS_core.git"
+      },
+      "ephys": {
+        "repository": "https://github.com/openMetadataInitiative/openMINDS_ephys.git"
+      },
+      "publications": {
+        "repository": "https://github.com/openMetadataInitiative/openMINDS_publications.git"
+      },
+      "specimenPrep": {
+        "repository": "https://github.com/openMetadataInitiative/openMINDS_specimenPrep.git"
+      },
+      "stimulation": {
+        "repository": "https://github.com/openMetadataInitiative/openMINDS_stimulation.git"
+      },
+      "neuroimaging": {
+        "repository": "https://github.com/openMetadataInitiative/openMINDS_neuroimaging"
+      }
+    },
+    "v1.0": {
+      "SANDS": {
+        "branch": "v1",
+        "commit": "e174e567600aa13fa81bc9c8f6bc1d7f9e7624c5",
+        "repository": "https://github.com/openMetadataInitiative/openMINDS_SANDS.git"
+      },
+      "controlledTerms": {
+        "branch": "v1",
+        "commit": "2400e43e873fbfadd9f776fa69bc541a86144c8a",
+        "repository": "https://github.com/openMetadataInitiative/openMINDS_controlledTerms.git"
+      },
+      "core": {
+        "branch": "v3",
+        "commit": "d328b5709bda8a61a3f1cb151780dfb5ef870b1a",
+        "repository": "https://github.com/openMetadataInitiative/openMINDS_core.git"
+      }
+    },
+    "v2.0": {
+      "SANDS": {
+        "branch": "v2",
+        "commit": "be95b2bee743f1443167dc59ec3ffcc00a51b7db",
+        "repository": "https://github.com/openMetadataInitiative/openMINDS_SANDS.git"
+      },
+      "controlledTerms": {
+        "branch": "v1",
+        "commit": "1fb6b233720c6ff36829a17c8025424a7db7f8f0",
+        "repository": "https://github.com/openMetadataInitiative/openMINDS_controlledTerms.git"
+      },
+      "core": {
+        "branch": "v3",
+        "commit": "8c61d390419d35ff53ef85a13a8c4a9587af682f",
+        "repository": "https://github.com/openMetadataInitiative/openMINDS_core.git"
+      }
+    },
+    "v3.0": {
+      "SANDS": {
+        "branch": "v3",
+        "commit": "ac2e238661c96bdfa98127b90dad35af6c132d50",
+        "repository": "https://github.com/openMetadataInitiative/openMINDS_SANDS.git"
+      },
+      "chemicals": {
+        "branch": "v1",
+        "commit": "57b5ce3c6d569f0bb8ce761adb48746fd1d970b2",
+        "repository": "https://github.com/openMetadataInitiative/openMINDS_chemicals.git"
+      },
+      "computation": {
+        "branch": "v1",
+        "commit": "57e160465c285be1780f74cffa80d16209e2a706",
+        "repository": "https://github.com/openMetadataInitiative/openMINDS_computation.git"
+      },
+      "controlledTerms": {
+        "branch": "v1",
+        "commit": "d8bc03dce7c5764f80e2ced630dde4e572ffbb7b",
+        "repository": "https://github.com/openMetadataInitiative/openMINDS_controlledTerms.git"
+      },
+      "core": {
+        "branch": "v4",
+        "commit": "8b2bc673cbd57a8620a306a7a84253bd6ecd30eb",
+        "repository": "https://github.com/openMetadataInitiative/openMINDS_core.git"
+      },
+      "ephys": {
+        "branch": "v1",
+        "commit": "2accac60e9dc50116c5eee8893cffcd5b1bf24c8",
+        "repository": "https://github.com/openMetadataInitiative/openMINDS_ephys.git"
+      },
+      "publications": {
+        "branch": "v1",
+        "commit": "d5446304a052a238d431a06bd66d0e444372f159",
+        "repository": "https://github.com/openMetadataInitiative/openMINDS_publications.git"
+      },
+      "specimenPrep": {
+        "branch": "v1",
+        "commit": "0669813dae142946a19f00645b0d8c2d66d01975",
+        "repository": "https://github.com/openMetadataInitiative/openMINDS_specimenPrep.git"
+      },
+      "stimulation": {
+        "branch": "v1",
+        "commit": "4dfdbadde9223ea9b6b48f377a424d23b1c8cf04",
+        "repository": "https://github.com/openMetadataInitiative/openMINDS_stimulation.git"
+      }
+    }
+  }


### PR DESCRIPTION
This modifies the pipeline to build both a "production" (-> main branch) and "development" (-> development branch) set of schemas. This will allow us to test in-development modules (like neuroimaging, at present) before they are merged.