### PR TITLE
Update versions.json to fix codespell error

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -80,7 +80,7 @@
     },
     "controlledTerms": {
       "branch": "v1",
-      "commit": "d8bc03dce7c5764f80e2ced630dde4e572ffbb7b",
+      "commit": "ec74648f99e9b02d4afde37c6aa7ae80919f460f",
       "repository": "https://github.com/openMetadataInitiative/openMINDS_controlledTerms.git"
     },
     "core": {


### PR DESCRIPTION
Changing the git commit id for controlledTerms in openMINDS v3.0, to point to a slightly newer commit in which a typo was fixed. This should get rid of codespell errors.