### PR TITLE
Update versions.json

### DIFF
--- a/versions-dev.json
+++ b/versions-dev.json
@@ -130,52 +130,42 @@
     "modules": {
       "SANDS": {
         "branch": "v4",
-        "commit": "9d3ed733c65ed0959364ee0255877224f5167414",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_SANDS.git"
       },
       "chemicals": {
         "branch": "v2",
-        "commit": "fab4986659c4abd6e9a41356b9cd7c6f0cf88cc5",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_chemicals.git"
       },
       "computation": {
         "branch": "v2",
-        "commit": "ada215e3ae768948918d651aa4ff99e3372f04fd",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_computation.git"
       },
       "controlledTerms": {
         "branch": "v2",
-        "commit": "2fd8b53fe1fdda8e8e7be79cce6426ce2d5360b3",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_controlledTerms.git"
       },
       "core": {
         "branch": "v5",
-        "commit": "5a64aa9dd0db8ac07b9010c7d51963d06f19a58f",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_core.git"
       },
       "ephys": {
         "branch": "v2",
-        "commit": "3a043926e04184a5c4dbb92992301303d5d79f31",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_ephys.git"
       },
       "publications": {
         "branch": "v2",
-        "commit": "104783cc7330ef4e4a9118b4de612c0eec46cc85",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_publications.git"
       },
       "specimenPrep": {
         "branch": "v2",
-        "commit": "10ee61dd93e614385772d5fc5fbe59f8016c8136",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_specimenPrep.git"
       },
       "stimulation": {
         "branch": "v2",
-        "commit": "da22d249e824dc02c1ad0e358f82430a2afa2a87",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_stimulation.git"
       },
       "neuroimaging": {
         "branch": "dev",
-        "commit": "e94c255620c8bb9cc1f42b8d3847a38f9b4ca710",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_neuroimaging.git"
       }
     }

--- a/versions.json
+++ b/versions.json
@@ -93,7 +93,7 @@
       },
       "chemicals": {
         "branch": "v1",
-        "commit": "aff2209e796ad1511baea62d27ab85e65113583c",
+        "commit": "20f321b06a596fd49044db0323b95c3ea6d8a272",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_chemicals.git"
       },
       "computation": {

--- a/versions.json
+++ b/versions.json
@@ -88,12 +88,12 @@
     "modules": {
       "SANDS": {
         "branch": "v3",
-        "commit": "ac2e238661c96bdfa98127b90dad35af6c132d50",
+        "commit": "2d72c428bce35c85828f7fb8acca4cda5eedc4fc",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_SANDS.git"
       },
       "chemicals": {
         "branch": "v1",
-        "commit": "57b5ce3c6d569f0bb8ce761adb48746fd1d970b2",
+        "commit": "aff2209e796ad1511baea62d27ab85e65113583c",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_chemicals.git"
       },
       "computation": {
@@ -108,7 +108,7 @@
       },
       "core": {
         "branch": "v4",
-        "commit": "8b2bc673cbd57a8620a306a7a84253bd6ecd30eb",
+        "commit": "8d2197b955c81c45b8d3437f47d2f8ff6f9af8b5",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_core.git"
       },
       "ephys": {
@@ -118,7 +118,7 @@
       },
       "publications": {
         "branch": "v1",
-        "commit": "d5446304a052a238d431a06bd66d0e444372f159",
+        "commit": "32ae078d248721afddaa3362b7b507aaa73b5cf6",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_publications.git"
       },
       "specimenPrep": {

--- a/versions.json
+++ b/versions.json
@@ -47,12 +47,12 @@
       },
       "controlledTerms": {
         "branch": "v1",
-        "commit": "2400e43e873fbfadd9f776fa69bc541a86144c8a",
+        "commit": "fd2a414b82c9c0b2fba4c881de38defad1189ef9",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_controlledTerms.git"
       },
       "core": {
         "branch": "v3",
-        "commit": "d328b5709bda8a61a3f1cb151780dfb5ef870b1a",
+        "commit": "eb6edffff97eadcc73830d84449ef7e631b35409",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_core.git"
       }
     }
@@ -93,7 +93,7 @@
       },
       "chemicals": {
         "branch": "v1",
-        "commit": "20f321b06a596fd49044db0323b95c3ea6d8a272",
+        "commit": "b4f83fc3aedd0e72fe0c29f5aa964b108cb7a69b",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_chemicals.git"
       },
       "computation": {


### PR DESCRIPTION
To get rid of the codespell errors in v3.0 I've manually updated the commits to build v3.0 for core, chemicals, publications, and SANDS in the versions file.

versions-dev.json fixed to only include last commit for each submodule version branch.

Fixed also commits for v1.0, because of errors in the schemas that were fixed to make v1.0 functioning.

@Raphael-Gazzotti please check