### PR TITLE
Change Neurostars link

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The framework also receives support from the [BigBrain Project](https://bigbrain
 The openMINDS metadata framework is closely collaborating with the [InterLex Project][interlex-dashboard] of the [SciCrunch Data and Resource Infrastructure][scicrunch-website] and the [KnowledgeSpace][ks-website] hosted by the [International Neuroinformatics Coordinating Facility (INCF)][incf-website].
 
 <!-- MARKDOWN LINKS & IMAGES -->
-[community-forum]: https://neurostars.org/c/institutions/openminds
+[community-forum]: https://neurostars.org/g/openMINDS
 [contribution-url]: https://openminds-documentation.readthedocs.io/en/latest/shared/contribution_guidelines.html
 [contributors-url]: https://github.com/openMetadataInitiative/openMINDS/graphs/contributors
 [contributors-shield]: https://img.shields.io/github/contributors/openMetadataInitiative/openMINDS

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The framework also receives support from the [BigBrain Project](https://bigbrain
 The openMINDS metadata framework is closely collaborating with the [InterLex Project][interlex-dashboard] of the [SciCrunch Data and Resource Infrastructure][scicrunch-website] and the [KnowledgeSpace][ks-website] hosted by the [International Neuroinformatics Coordinating Facility (INCF)][incf-website].
 
 <!-- MARKDOWN LINKS & IMAGES -->
-[community-forum]: https://neurostars.org/t/about-the-openminds-category/31428
+[community-forum]: https://neurostars.org/c/institutions/openminds
 [contribution-url]: https://openminds-documentation.readthedocs.io/en/latest/shared/contribution_guidelines.html
 [contributors-url]: https://github.com/openMetadataInitiative/openMINDS/graphs/contributors
 [contributors-shield]: https://img.shields.io/github/contributors/openMetadataInitiative/openMINDS


### PR DESCRIPTION
The current Neurostars link in the README goes to a specific thread [About the openMINDS category](https://neurostars.org/t/about-the-openminds-category/31428) in the openMINDS category, which is informative, but it's not obvious from that page how to start new threads, so that people can ask questions.

I suggest changing the link to the home page for openMINDS questions, [here](https://neurostars.org/c/institutions/openminds).