### PR TITLE
Exclude '.git' from rsync deletion process.

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Push to development
       run: |
-        rsync -a --delete target/ development/
+        rsync -a --delete --exclude '.git/' target/ development/
         cd development
         git config --global user.email "support@openmetadatainitiative.org"
         git config --global user.name "openMINDS pipeline"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Push to main
       run: |
-        rsync -a --delete target/ main/
+        rsync -a --delete --exclude '.git/' target/ main/
         cd main
         git config --global user.email "support@openmetadatainitiative.org"
         git config --global user.name "openMINDS pipeline"


### PR DESCRIPTION
Pipeline is currently failing due to commit 511d4955923a87b49d5e5fac1500a8e3d86a5244.

@olinux identified that the issue is caused by the hidden ".git" folder being deleted when using the command "rsync -a --delete". This deletion prevents proper pushes to the relevant branches, because the folders are no longer recognized as Git repositories.