### PR TITLE
Bump neuroimaging commit for v5.0 to include device fix

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -228,7 +228,7 @@
       },
       "neuroimaging": {
         "branch": "v1",
-        "commit": "fe3b615b718065860c342cb2490f1ec5203791c7",
+        "commit": "3f2838a857b0d8832fe2d4617847d92dbf7360bb",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_neuroimaging.git"
       },
       "publications": {


### PR DESCRIPTION
Fixes #99

Updates the `neuroimaging` pin for v5.0 in `versions.json` from
`fe3b615b718065860c342cb2490f1ec5203791c7` to
`3f2838a857b0d8832fe2d4617847d92dbf7360bb` (current v1 HEAD).

The old pin predated openMetadataInitiative/openMINDS_neuroimaging#60, which
added `device` to `MRIScannerUsage.schema.tpl.json`. As a result, the compiled
`MRIScannerUsage.schema.omi.json` for v5.0 was missing `device` from its
`properties` block even though it appeared in `required`.

## Commits between old and new pin

Four commits are brought in by this bump:

| Commit | Description |
|---|---|
| `bec65af` | `MRIScannerUsage.schema.tpl.json` — adds `device` property (the fix, openMetadataInitiative/openMINDS_neuroimaging#60) |
| `9660565` | Merge commit for the above PR — no file changes |
| `6ac841a` | `.github/workflows/openMINDS_upstream.yml` — one line added to a CI workflow trigger, no schema impact |
| `3f2838a` | Merge commit for the above — no file changes |

No schema files are touched other than the `device` fix itself, so there is no risk of unintended schema changes.