### PR TITLE
Update commit hash for SANDS module in versions.json for v5.0

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -198,7 +198,7 @@
     "modules": {
       "SANDS": {
         "branch": "v5",
-        "commit": "0f0fc3fa1fb8b38e34826c142aa46fd8fb280c23",
+        "commit": "e3c3443148235e68c64980a2b7b01788805e41cc",
         "repository": "https://github.com/openMetadataInitiative/openMINDS_SANDS.git"
       },
       "chemicals": {


### PR DESCRIPTION
Commits [2f5e244822b7eee6c02e10f786f51e47fa44052c](https://github.com/openMetadataInitiative/openMINDS_SANDS/commit/2f5e244822b7eee6c02e10f786f51e47fa44052c) and [e3c3443148235e68c64980a2b7b01788805e41cc](https://github.com/openMetadataInitiative/openMINDS_SANDS/commit/e3c3443148235e68c64980a2b7b01788805e41cc) introduced changes to the instructions.